### PR TITLE
fix(handlers): AttributeError

### DIFF
--- a/src/korone/handlers/base.py
+++ b/src/korone/handlers/base.py
@@ -46,8 +46,14 @@ class BaseHandler:
         raise ValueError(msg)
 
     async def _fetch_locale(self, update: Update) -> str:
-        message, user = await self._extract_message_and_user(update)
+        try:
+            message, user = await self._extract_message_and_user(update)
+        except ValueError:
+            return i18n.default_locale
+
         chat = message.chat
+        if chat is None:
+            return i18n.default_locale
 
         if user and chat.type == ChatType.PRIVATE:
             return await self._fetch_locale_from_db(user)


### PR DESCRIPTION
Fixes #277

Add validation to handle `NoneType` for `chat` attribute in `_fetch_locale` method.

* Add a try-except block in `_fetch_locale` method to catch `ValueError` and return `i18n.default_locale`.
* Add a check to verify if `chat` is `None` before accessing `chat.type` and return `i18n.default_locale` if it is `None`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HitaloM/PyKorone/issues/277?shareId=2dc8d9b6-d660-44b7-877d-4873ab7b769b).

## Summary by Sourcery

Bug Fixes:
- Add validation to handle 'NoneType' for 'chat' attribute in '_fetch_locale' method to prevent 'AttributeError'.