### PR TITLE
Fix AttributeError: 'NoneType' object has no attribute 'type'

### DIFF
--- a/src/korone/handlers/base.py
+++ b/src/korone/handlers/base.py
@@ -95,6 +95,9 @@ class BaseHandler:
         except ValueError:
             return None
 
+        if message.chat is None:
+            return None
+
         if isinstance(update, CallbackQuery):
             await self._store_user_or_chat(user)
         else:
@@ -201,6 +204,9 @@ class BaseHandler:
         if await self._process_migration(message):
             return
 
+        if message.chat is None:
+            return
+
         await self._process_private_and_group_messages(message)
 
         if message.chat.type not in {ChatType.GROUP, ChatType.SUPERGROUP}:
@@ -221,6 +227,9 @@ class BaseHandler:
         return bool(message.migrate_to_chat_id)
 
     async def _process_private_and_group_messages(self, message: Message) -> None:
+        if message.chat is None:
+            return
+
         if message.from_user and not message.from_user.is_bot:
             await self._store_user_or_chat(message.from_user, message.from_user.language_code)
         if message.chat.type in {ChatType.GROUP, ChatType.SUPERGROUP}:

--- a/src/korone/handlers/callback_query_handler.py
+++ b/src/korone/handlers/callback_query_handler.py
@@ -17,6 +17,6 @@ if TYPE_CHECKING:
 class KoroneCallbackQueryHandler(CallbackQueryHandler, BaseHandler):
     async def check(self, client: Client, callback: CallbackQuery) -> None:
         if callback.message.chat is None:
-            return
+            return None
 
         return await self._check_and_handle(client, callback)

--- a/src/korone/handlers/callback_query_handler.py
+++ b/src/korone/handlers/callback_query_handler.py
@@ -16,4 +16,7 @@ if TYPE_CHECKING:
 
 class KoroneCallbackQueryHandler(CallbackQueryHandler, BaseHandler):
     async def check(self, client: Client, callback: CallbackQuery) -> None:
+        if callback.message.chat is None:
+            return
+
         return await self._check_and_handle(client, callback)

--- a/src/korone/handlers/message_handler.py
+++ b/src/korone/handlers/message_handler.py
@@ -16,4 +16,7 @@ if TYPE_CHECKING:
 
 class KoroneMessageHandler(MessageHandler, BaseHandler):
     async def check(self, client: Client, message: Message) -> None:
+        if message.chat is None:
+            return
+
         return await self._check_and_handle(client, message)

--- a/src/korone/handlers/message_handler.py
+++ b/src/korone/handlers/message_handler.py
@@ -17,6 +17,6 @@ if TYPE_CHECKING:
 class KoroneMessageHandler(MessageHandler, BaseHandler):
     async def check(self, client: Client, message: Message) -> None:
         if message.chat is None:
-            return
+            return None
 
         return await self._check_and_handle(client, message)


### PR DESCRIPTION
Fixes #279

Add checks for `None` before accessing `message.chat` properties to prevent `AttributeError`.

* **`src/korone/handlers/base.py`**
  - Add a check in `_process_update` to ensure `message.chat` is not `None` before accessing its properties.
  - Add a check in `_process_message` to ensure `message.chat` is not `None` before accessing its properties.
  - Add a check in `_process_private_and_group_messages` to ensure `message.chat` is not `None` before accessing its properties.

* **`src/korone/handlers/message_handler.py`**
  - Add a check in `check` method to ensure `message.chat` is not `None` before accessing its properties.

* **`src/korone/handlers/callback_query_handler.py`**
  - Add a check in `check` method to ensure `callback.message.chat` is not `None` before accessing its properties.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HitaloM/PyKorone/issues/279?shareId=dc7a3929-48cc-4e31-89af-e50f2a210565).

## Summary by Sourcery

Bug Fixes:
- Add checks for 'None' before accessing 'message.chat' properties in various handler methods to prevent 'AttributeError'.