### PR TITLE
Update regex of media module to detect additional domains

### DIFF
--- a/src/korone/modules/medias/handlers/instagram.py
+++ b/src/korone/modules/medias/handlers/instagram.py
@@ -22,7 +22,7 @@ from korone.modules.medias.utils.cache import MediaCache
 from korone.modules.medias.utils.instagram.scraper import POST_PATTERN, fetch_instagram
 from korone.utils.i18n import gettext as _
 
-URL_PATTERN = re.compile(r"(?:https?://)?(?:www\.)?instagram\.com/.*?(?=\s|$)")
+URL_PATTERN = re.compile(r"(?:https?://)?(?:www\.)?(instagram\.com|ddinstagram\.com)/.*?(?=\s|$)")
 
 
 @router.message(Regex(URL_PATTERN))

--- a/src/korone/modules/medias/handlers/twitter.py
+++ b/src/korone/modules/medias/handlers/twitter.py
@@ -29,7 +29,7 @@ from korone.modules.medias.utils.twitter.types import MediaVariants as TweetMedi
 from korone.modules.medias.utils.twitter.types import Tweet
 from korone.utils.i18n import gettext as _
 
-URL_PATTERN = re.compile(r"(?:(?:http|https):\/\/)?(?:www.)?(twitter\.com|x\.com)/.+?/status/\d+")
+URL_PATTERN = re.compile(r"(?:(?:http|https):\/\/)?(?:www.)?(twitter\.com|x\.com|vxtwitter\.com|fxtwitter\.com|fixupx\.com|fixvx\.com)/.+?/status/\d+")
 
 
 @router.message(Regex(URL_PATTERN))


### PR DESCRIPTION
Update regex patterns to detect additional domains for Instagram and Twitter links.

* Update the regex pattern in `src/korone/modules/medias/handlers/instagram.py` to detect `ddinstagram.com` links.
* Update the regex pattern in `src/korone/modules/medias/handlers/twitter.py` to detect `vxtwitter.com`, `fxtwitter.com`, `fixupx.com`, and `fixvx.com` links.

